### PR TITLE
Added market_hash_name field

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function (user, game, gotOptions) {
 				amount: temp.amount,
 				pos: temp.pos,
 				name: item.name,
+				market_hash_name: item.market_hash_name,
 				appid: item.appid,
 				classid: item.classid,
 				instanceid: item.instanceid,

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (user, game, gotOptions) {
 				amount: temp.amount,
 				pos: temp.pos,
 				name: item.name,
-				market_hash_name: item.market_hash_name,
+				marketHashName: item.market_hash_name,
 				appid: item.appid,
 				classid: item.classid,
 				instanceid: item.instanceid,


### PR DESCRIPTION
Faced a problem where i need to get item names as in market. The 'name' field will return only skin name, without exterior. So i need to do it on my own, and check if there is exterior, because it can be a sticker. And steam have market_hash_name field, so would be nice to have it.